### PR TITLE
[Build] Fix manifest order

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="fr.tvbarthel.apps.shapi">
+<manifest package="fr.tvbarthel.apps.shapi"
+    xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"
@@ -8,6 +8,8 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
+        
+        <activity android:name=".MainActivity" />
 
         <activity-alias
             android:name=".Launcher"
@@ -18,7 +20,6 @@
             </intent-filter>
         </activity-alias>
 
-        <activity android:name=".MainActivity" />
     </application>
 
 </manifest>


### PR DESCRIPTION
Activity should be declared before the alias otherwise
a failure occured at install time:
INSTALL_PARSE_FAILED_MANIFEST_MALFORMED