### PR TITLE
[Drop Zone] Make drop zone bigger

### DIFF
--- a/app/src/main/res/layout-w820dp/one_drop_zones_field_view.xml
+++ b/app/src/main/res/layout-w820dp/one_drop_zones_field_view.xml
@@ -13,7 +13,7 @@
         android:layout_width="@dimen/drop_zone_box_width"
         android:layout_height="@dimen/drop_zone_box_height"
         android:layout_gravity="center_vertical|end"
-        android:layout_margin="@dimen/activity_horizontal_margin"
+        android:padding="@dimen/drop_zone_padding"
         android:background="?selectableItemBackground" />
 
 </merge>

--- a/app/src/main/res/layout-w820dp/two_drop_zones_field_view.xml
+++ b/app/src/main/res/layout-w820dp/two_drop_zones_field_view.xml
@@ -13,15 +13,15 @@
         android:layout_width="@dimen/drop_zone_box_width"
         android:layout_height="@dimen/drop_zone_box_height"
         android:layout_gravity="center_vertical|end"
-        android:layout_margin="@dimen/activity_horizontal_margin"
-        android:background="?selectableItemBackground" />
+        android:background="?selectableItemBackground"
+        android:padding="@dimen/drop_zone_padding" />
 
     <fr.tvbarthel.apps.shapi.game.DropZoneView
         android:id="@+id/field_view_drop_zone_2"
         android:layout_width="@dimen/drop_zone_box_width"
         android:layout_height="@dimen/drop_zone_box_height"
         android:layout_gravity="center_vertical|start"
-        android:layout_margin="@dimen/activity_horizontal_margin"
-        android:background="?selectableItemBackground" />
+        android:background="?selectableItemBackground"
+        android:padding="@dimen/drop_zone_padding" />
 
 </merge>

--- a/app/src/main/res/layout/four_drop_zones_field_view.xml
+++ b/app/src/main/res/layout/four_drop_zones_field_view.xml
@@ -13,31 +13,31 @@
         android:layout_width="@dimen/drop_zone_box_width"
         android:layout_height="@dimen/drop_zone_box_height"
         android:layout_gravity="start|top"
-        android:layout_margin="@dimen/activity_horizontal_margin"
-        android:background="?selectableItemBackground" />
+        android:background="?selectableItemBackground"
+        android:padding="@dimen/drop_zone_padding" />
 
     <fr.tvbarthel.apps.shapi.game.DropZoneView
         android:id="@+id/field_view_drop_zone_2"
         android:layout_width="@dimen/drop_zone_box_width"
         android:layout_height="@dimen/drop_zone_box_height"
         android:layout_gravity="end|top"
-        android:layout_margin="@dimen/activity_horizontal_margin"
-        android:background="?selectableItemBackground" />
+        android:background="?selectableItemBackground"
+        android:padding="@dimen/drop_zone_padding" />
 
     <fr.tvbarthel.apps.shapi.game.DropZoneView
         android:id="@+id/field_view_drop_zone_3"
         android:layout_width="@dimen/drop_zone_box_width"
         android:layout_height="@dimen/drop_zone_box_height"
         android:layout_gravity="start|bottom"
-        android:layout_margin="@dimen/activity_horizontal_margin"
-        android:background="?selectableItemBackground" />
+        android:background="?selectableItemBackground"
+        android:padding="@dimen/drop_zone_padding" />
 
     <fr.tvbarthel.apps.shapi.game.DropZoneView
         android:id="@+id/field_view_drop_zone_4"
         android:layout_width="@dimen/drop_zone_box_width"
         android:layout_height="@dimen/drop_zone_box_height"
         android:layout_gravity="end|bottom"
-        android:layout_margin="@dimen/activity_horizontal_margin"
-        android:background="?selectableItemBackground" />
+        android:background="?selectableItemBackground"
+        android:padding="@dimen/drop_zone_padding" />
 
 </merge>

--- a/app/src/main/res/layout/one_drop_zones_field_view.xml
+++ b/app/src/main/res/layout/one_drop_zones_field_view.xml
@@ -13,7 +13,7 @@
         android:layout_width="@dimen/drop_zone_box_width"
         android:layout_height="@dimen/drop_zone_box_height"
         android:layout_gravity="center_horizontal|bottom"
-        android:layout_margin="@dimen/activity_horizontal_margin"
+        android:padding="@dimen/drop_zone_padding"
         android:background="?selectableItemBackground" />
 
 </merge>

--- a/app/src/main/res/layout/two_drop_zones_field_view.xml
+++ b/app/src/main/res/layout/two_drop_zones_field_view.xml
@@ -13,7 +13,7 @@
         android:layout_width="@dimen/drop_zone_box_width"
         android:layout_height="@dimen/drop_zone_box_height"
         android:layout_gravity="center_horizontal|bottom"
-        android:layout_margin="@dimen/activity_horizontal_margin"
+        android:padding="@dimen/drop_zone_padding"
         android:background="?selectableItemBackground" />
 
     <fr.tvbarthel.apps.shapi.game.DropZoneView
@@ -21,7 +21,7 @@
         android:layout_width="@dimen/drop_zone_box_width"
         android:layout_height="@dimen/drop_zone_box_height"
         android:layout_gravity="center_horizontal|top"
-        android:layout_margin="@dimen/activity_horizontal_margin"
+        android:padding="@dimen/drop_zone_padding"
         android:background="?selectableItemBackground" />
 
 </merge>

--- a/app/src/main/res/values-w820dp/dimens.xml
+++ b/app/src/main/res/values-w820dp/dimens.xml
@@ -7,8 +7,9 @@
     <dimen name="shape_size">150dp</dimen>
     <dimen name="shape_border_width">4dp</dimen>
 
-    <dimen name="drop_zone_box_width">180dp</dimen>
-    <dimen name="drop_zone_box_height">180dp</dimen>
+    <dimen name="drop_zone_box_width">308dp</dimen>
+    <dimen name="drop_zone_box_height">308dp</dimen>
+    <dimen name="drop_zone_padding">64dp</dimen>
     <dimen name="drop_zone_box_internal_shape_padding">4dp</dimen>
     <dimen name="drop_zone_box_internal_shape_width">80dp</dimen>
     <dimen name="drop_zone_box_internal_shape_height">80dp</dimen>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -6,8 +6,9 @@
     <dimen name="shape_size">100dp</dimen>
     <dimen name="shape_border_width">2dp</dimen>
 
-    <dimen name="drop_zone_box_width">120dp</dimen>
-    <dimen name="drop_zone_box_height">120dp</dimen>
+    <dimen name="drop_zone_box_width">152dp</dimen>
+    <dimen name="drop_zone_box_height">152dp</dimen>
+    <dimen name="drop_zone_padding">16dp</dimen>
     <dimen name="drop_zone_box_internal_shape_padding">2dp</dimen>
     <dimen name="drop_zone_box_internal_shape_width">60dp</dimen>
     <dimen name="drop_zone_box_internal_shape_height">60dp</dimen>


### PR DESCRIPTION
The drop zone are now bigger so that
kids see the visual feedback before
actually hoovering the shapi images.